### PR TITLE
hdl.handle.net prefix

### DIFF
--- a/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
+++ b/src/MCPClient/lib/clientScripts/post_store_aip_hook.py
@@ -68,7 +68,7 @@ def dspace_handle_to_archivesspace(sip_uuid):
     # Update
     url = archivesspace_url + digital_object.remoteid
     file_version = {
-        "file_uri": handle,
+        "file_uri": "http://hdl.handle.net/" + handle,
         "use_statement": config.use_statement,
         "xlink_show_attribute": config.xlink_show,
         "xlink_actuate_attribute": config.xlink_actuate,


### PR DESCRIPTION
Adds the preferred "http://hdl.handle.net/" prefix to the Handle so that the full URL gets posted to ArchivesSpace.